### PR TITLE
-- Dashboard header 1024x768 video projectors  support.

### DIFF
--- a/www/libs/css/dashboard.css
+++ b/www/libs/css/dashboard.css
@@ -382,3 +382,22 @@ li.dropdown .dropdown-toggle {
 #updateProgressChart {
   margin-left: 110px;
 }
+/* Custom css for 1024*768 resolution */
+@media (min-width: 980px) and (max-width: 1024px) {
+  #controlCenter {
+    width: auto !important;
+    top: 0 !important;
+    left: 0 !important;
+    display: block;
+    float: left;
+    position: relative !important;
+  }
+  #statusBar {
+    width: 100% !important;
+    float: none !important;
+    padding: 2px 6px;
+    margin: 11px 12px 0 0;
+  }
+
+
+}


### PR DESCRIPTION
-- This fix will provide dashboard preview on video projectors resolution 1024x768. 
    Its a quick fix, and it will only support exactly requested resolution (1024x768).
