### PR TITLE
Fixed #157 by detaching the interrupt on the firmware

### DIFF
--- a/IoTPy/pyuper/gpio.py
+++ b/IoTPy/pyuper/gpio.py
@@ -194,6 +194,8 @@ class UPER1_GPIO(GPIO):
             return False
 
         self.board.interrupts[irq_id] = None
+        del self.board.callbackdict[self.logical_pin]
+        self.board.uper_io(0, self.board.encode_sfp(7, [irq_id]))
         return True
 
     def get_irq_count(self):


### PR DESCRIPTION
The firmware function (command 7) was not called, so the interrupt was still active in the firmware.
In addition, delete the entry in the *callbackdict* when the IRQ is detached