### PR TITLE
Symlink of ttyACM0 and ttyACM1, and use the symlink in ioboard.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 WeIO 1.1, not released yet
 -------------------
 - IDE
- - Improved the console output a5c3785ed8d6a35868bc169f07e40e889087fd2e
+ - Improved the console output 
  - Improved the preview
  - Added an option to enable/disable the login requirement to access the IDE
  - Improved the way new projects are created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+WeIO 1.1, not released yet
+-------------------
+- IDE
+  - Improved the console output
+  - Improved the preview
+  - Added an option to enable/disable the login requirement to access the IDE
+  - Improved the way new projects are created
+
+- API
+  - Added a debounce time parameter for interrupts
+  - Added support for interrupts in javascript
+  - Fixed a bug with detachInterrupt function
+  - Fixed the initSerial parameters
+  - Improved stability of IoTPy
+
+- System
+  - Support for bluetooth + bluez
+  - Update of NTPD timezones
+  - Improved samba behavior
+
+- Examples
+  - Fixed webCamSinglePhotoWEB example
+  - Added twitter_PY example
+  - Added interrupt_JS example
+
+
+WeIO 1.0, 2015/02/04
+--------------------
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 WeIO 1.1, not released yet
 -------------------
 - IDE
-  - Improved the console output
-  - Improved the preview
-  - Added an option to enable/disable the login requirement to access the IDE
-  - Improved the way new projects are created
+ - Improved the console output a5c3785ed8d6a35868bc169f07e40e889087fd2e
+ - Improved the preview
+ - Added an option to enable/disable the login requirement to access the IDE
+ - Improved the way new projects are created
 
 - API
   - Added a debounce time parameter for interrupts

--- a/IoTPy/pyuper/ioboard.py
+++ b/IoTPy/pyuper/ioboard.py
@@ -50,7 +50,7 @@ class IoBoard:
                 ports_list = glob.glob("/dev/tty.usbmodem*")
             elif my_platform == "Linux":
 		if platform.machine() == 'mips': # MIPS : This is probably WeIO
-		    ports_list = "/dev/lpc"
+		    ports_list = glob.glob("/dev/lpc")
 		else:
 		    ports_list = glob.glob("/dev/ttyACM*")
         for my_port in ports_list:

--- a/IoTPy/pyuper/ioboard.py
+++ b/IoTPy/pyuper/ioboard.py
@@ -49,7 +49,10 @@ class IoBoard:
             elif my_platform == "Darwin":
                 ports_list = glob.glob("/dev/tty.usbmodem*")
             elif my_platform == "Linux":
-                ports_list = glob.glob("/dev/ttyACM*")
+		if platform.machine() == 'mips': # MIPS : This is probably WeIO
+		    ports_list = "/dev/lpc"
+		else:
+		    ports_list = glob.glob("/dev/ttyACM*")
         for my_port in ports_list:
             try:
                 port_to_try = serial.Serial(

--- a/openWrt/files/etc/hotplug.d/usb/10-weio-tty-symlinks
+++ b/openWrt/files/etc/hotplug.d/usb/10-weio-tty-symlinks
@@ -1,0 +1,29 @@
+#!/bin/sh
+PRODID="257f/1/100"
+IFACEID="2/2/0"
+SYMLINK="lpc"
+if [ "${PRODUCT}" = "${PRODID}" ];
+    then if [ "${ACTION}" = "add" ];
+        then
+            DEVICE_NAME=$(ls /sys/$DEVPATH/tty/ | grep tty)
+            if [ -z ${DEVICE_NAME} ]; then
+                exit
+            fi
+            if [ "${INTERFACE}" = "${IFACEID}" ]; then
+                a=`cat /sys/$DEVPATH/bInterfaceNumber`
+                if [ $a = "00" ]; then
+                    ln -s /dev/$DEVICE_NAME /dev/lpc
+                    logger -t Hotplug Symlink from /dev/$DEVICE_NAME to /dev/lpc created
+                elif [ $a = "02" ]; then
+                    ln -s /dev/$DEVICE_NAME /dev/lpcUart
+                    logger -t Hotplug Symlink from /dev/$DEVICE_NAME to /dev/lpcUart created 
+                fi
+            fi
+    fi
+fi
+if [ "${PRODUCT}" = "${PRODID}" ];
+    then if [ "${ACTION}" = "remove" ];
+        then rm -f /dev/${SYMLINK}*
+        logger -t Hotplug Symlink /dev/${SYMLINK} removed
+    fi
+fi

--- a/openWrt/files/etc/hotplug2.rules
+++ b/openWrt/files/etc/hotplug2.rules
@@ -1,6 +1,6 @@
 $include /etc/hotplug2-common.rules
 
-SUBSYSTEM ~~ (^net$|^input$|button$|^usb$|^ieee1394$|^block$|^atm$|^zaptel$|^tty$|weio$) {
+SUBSYSTEM ~~ (^net$|^input$|button$|usb$|^ieee1394$|^block$|^atm$|^zaptel$|^tty$|weio$) {
 	exec /sbin/hotplug-call %SUBSYSTEM%
 }
 	 

--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -56,6 +56,10 @@ cd /weio/scripts/
 cd /weio
 rm /tmp/config.weio
 
+# Populate system with the new files
+cp -r /weio/scripts/update/* /
+rm -r /weio/scripts/update
+
 # flashing new firmware to LPC chip
 cd /weio/scripts/
 ./flash_lpc_fw.py

--- a/scripts/update/etc/hotplug.d/usb/10-weio-tty-symlinks
+++ b/scripts/update/etc/hotplug.d/usb/10-weio-tty-symlinks
@@ -1,0 +1,29 @@
+#!/bin/sh
+PRODID="257f/1/100"
+IFACEID="2/2/0"
+SYMLINK="lpc"
+if [ "${PRODUCT}" = "${PRODID}" ];
+    then if [ "${ACTION}" = "add" ];
+        then
+            DEVICE_NAME=$(ls /sys/$DEVPATH/tty/ | grep tty)
+            if [ -z ${DEVICE_NAME} ]; then
+                exit
+            fi
+            if [ "${INTERFACE}" = "${IFACEID}" ]; then
+                a=`cat /sys/$DEVPATH/bInterfaceNumber`
+                if [ $a = "00" ]; then
+                    ln -s /dev/$DEVICE_NAME /dev/lpc
+                    logger -t Hotplug Symlink from /dev/$DEVICE_NAME to /dev/lpc created
+                elif [ $a = "02" ]; then
+                    ln -s /dev/$DEVICE_NAME /dev/lpcUart
+                    logger -t Hotplug Symlink from /dev/$DEVICE_NAME to /dev/lpcUart created 
+                fi
+            fi
+    fi
+fi
+if [ "${PRODUCT}" = "${PRODID}" ];
+    then if [ "${ACTION}" = "remove" ];
+        then rm -f /dev/${SYMLINK}*
+        logger -t Hotplug Symlink /dev/${SYMLINK} removed
+    fi
+fi

--- a/scripts/update/etc/hotplug2.rules
+++ b/scripts/update/etc/hotplug2.rules
@@ -1,0 +1,10 @@
+$include /etc/hotplug2-common.rules
+
+SUBSYSTEM ~~ (^net$|^input$|button$|usb$|^ieee1394$|^block$|^atm$|^zaptel$|^tty$|weio$) {
+	exec /sbin/hotplug-call %SUBSYSTEM%
+}
+	 
+DEVICENAME == watchdog {
+	exec /sbin/watchdog -t 5 /dev/watchdog
+	 next-event
+}


### PR DESCRIPTION
We've noticed a strange behavior with the DS18B20 temperature sensor, and it appeared that the problem come from the LPC detection process in IoTPy.
This update fixes the problem by using a symlink to the correct ttyACM device, and don't parses all the devices anymore.

Ref. http://we-io.net/forum/viewtopic.php?f=13&t=362