### PR TITLE
Fixed a bug with duplication from SD to flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ WeIO 1.1, not released yet
  - Improved the way new projects are created [[#156](https://github.com/nodesign/weio/pull/156)]
  - Added an auto-save function [[b99325f](https://github.com/nodesign/weio/commit/b99325f78c02ed27189bc13bb42c01ea57b94564)]
  - Fixed dashboard preview on lower resolution [[#166](https://github.com/nodesign/weio/pull/166)]
- - Improved the pin visualization [[#166](https://github.com/nodesign/weio/pull/166)]
+ - Improved the pin visualization [[#166](https://github.com/nodesign/weio/pull/166)] [[6651fc8](https://github.com/nodesign/weio/commit/6651fc8472eafc8e7eb555435e9aa345e0136b2d)]
+ - Fixed a bug with duplication [[#104](https://github.com/nodesign/weio/issues/104)] [[#179](https://github.com/nodesign/weio/pull/179)]
+ - Added support for creating / editing shell scripts [[2740a52](https://github.com/nodesign/weio/commit/2740a526e458ee3910dbbc7d8cb0c66bb871a3e8)]
+ - Added a logo at login screen [[7472dad](https://github.com/nodesign/weio/commit/7472dad7f1c2674a54740509aa66618f44f68b08)]
 
 - API
   - Added a debounce time parameter for interrupts [[d2a9fe2](https://github.com/nodesign/weio/commit/d2a9fe2ca3153ad3a22f53810a047d6958fb9f89)]
@@ -29,6 +32,8 @@ WeIO 1.1, not released yet
   - Added twitter_PY example [[#139](https://github.com/nodesign/weio/pull/139)]
   - Added interrupt_JS example [[3ef5b1d](https://github.com/nodesign/weio/commit/3ef5b1ddc7d5093c1ac7a8cd5494f5ea86e4169d)]
   - Added an example for the DS18B20 temperature sensor [[#165](https://github.com/nodesign/weio/pull/165)]
+  - Added an example to play wave files [[c786e8d](https://github.com/nodesign/weio/commit/c786e8d12e74b82a44c1f1cd481397f27db62a55)]
+  - Added an example to play internet radio [[ed10165](https://github.com/nodesign/weio/commit/ed101654b08357e2891450fe45268e20b42f7d73)]
 
 
 WeIO 1.0, 2015/02/04

--- a/www/libs/weio/dashboard.js
+++ b/www/libs/weio/dashboard.js
@@ -844,7 +844,7 @@ function updateProjects(data) {
     tag+='<ul class="nav nav-pills">';
 
     for (var i=0; i<data.data.length; i++) {
-        if (i==0) 
+        if (data.data[i].storageName==selectedStorageUnit)
             tag+='<li class="active" id="' + data.data[i].storageName +
                     'StorageUnit'+'"><a href="#">' + data.data[i].storageName + '</a></li>';
         else

--- a/www/libs/weio/dashboard.js
+++ b/www/libs/weio/dashboard.js
@@ -844,7 +844,10 @@ function updateProjects(data) {
     tag+='<ul class="nav nav-pills">';
 
     for (var i=0; i<data.data.length; i++) {
-        if (data.data[i].storageName==selectedStorageUnit)
+        if (i == 0 && selectedStorageUnit == null)
+            tag+='<li class="active" id="' + data.data[i].storageName +
+                    'StorageUnit'+'"><a href="#">' + data.data[i].storageName + '</a></li>';
+        else if (data.data[i].storageName==selectedStorageUnit)
             tag+='<li class="active" id="' + data.data[i].storageName +
                     'StorageUnit'+'"><a href="#">' + data.data[i].storageName + '</a></li>';
         else


### PR DESCRIPTION
The storage unit selected (class="active") must be the selectedStorageUnit, and not the first in the list.
So, it the latest selectedStorageUnit is "sd", then SD will be displayed as selected.

This fix bug #104 