### PR TITLE
Improved the reader loop of IoTPy and fix weioSPI and weioSmb

### DIFF
--- a/weioLib/weioSPI.py
+++ b/weioLib/weioSPI.py
@@ -53,10 +53,10 @@
 from weioLib.weio import initSPI
 from struct import pack, unpack
 
-SPI_FUNC_READ_BLOCK_DATA = 32
 
 class SPILib(object):
     _spi = None
+    SPI_FUNC_READ_BLOCK_DATA = 32
 
     def __init__(self, port=0, divider=1, mode=0):
         self.open(port, divider, mode)
@@ -77,6 +77,12 @@ class SPILib(object):
         Connects the object to the specified SPI port.
         """
         self._spi = initSPI(port, divider, mode)
+
+    def get_block_size(self):
+        return self.SPI_FUNC_READ_BLOCK_DATA
+
+    def set_block_size(self, block_size):
+	self.SPI_FUNC_READ_BLOCK_DATA = block_size
 
     def read_byte(self):
         """read_byte(self) -> result
@@ -129,12 +135,12 @@ class SPILib(object):
         Perform SPI Read Block Data transaction.
         """
         receiveFlags = ""
-        sendFlags = "B"
-        for flag in range(SPI_FUNC_READ_BLOCK_DATA):
-            sendFlags+="B"
+	cmdString = pack('B', cmd)
+        for flag in range(self.SPI_FUNC_READ_BLOCK_DATA):
+            cmdString+=pack('B', 0)
             receiveFlags+="B"
 
-        result = self._spi.transaction(pack(sendFlags, cmd, chr(0)*SPI_FUNC_READ_BLOCK_DATA), read_from_slave=True)
+        result = self._spi.transaction(cmdString, read_from_slave=True)
         return list(unpack(receiveFlags, result[0]))
 
     def write_block_data(self, cmd, vals):

--- a/weioLib/weioSmbus.py
+++ b/weioLib/weioSmbus.py
@@ -53,12 +53,12 @@
 from weioLib.weio import initI2C
 from struct import pack, unpack
 
-I2C_FUNC_SMBUS_READ_BLOCK_DATA = 32
 
 class SMBus(object):
     _i2c = None
     _addr = -1
     _compat = False
+    I2C_FUNC_SMBUS_READ_BLOCK_DATA = 32
 
     def __init__(self, bus=-1):
         # WeIO don't care about bus as there is only one.
@@ -83,6 +83,12 @@ class SMBus(object):
         Connects the object to the specified SMBus.
         """
         self._i2c = initI2C()
+
+    def get_block_size(self):
+        return self.I2C_FUNC_SMBUS_READ_BLOCK_DATA
+
+    def set_block_size(self, block_size):
+	self.I2C_FUNC_SMBUS_READ_BLOCK_DATA = block_size
 
     def _set_addr(self, addr):
         """private helper method"""
@@ -178,9 +184,9 @@ class SMBus(object):
         Perform SMBus Read Block Data transaction.
         """
         self._set_addr(addr)
-        result = self._i2c.transaction(self._addr, pack('B', cmd), I2C_FUNC_SMBUS_READ_BLOCK_DATA)
+        result = self._i2c.transaction(self._addr, pack('B', cmd), self.I2C_FUNC_SMBUS_READ_BLOCK_DATA)
         dataFlags = ""
-        for flag in range(I2C_FUNC_SMBUS_READ_BLOCK_DATA):
+        for flag in range(self.I2C_FUNC_SMBUS_READ_BLOCK_DATA):
             dataFlags+="B"
         return list(unpack(dataFlags, result[0]))
 
@@ -208,10 +214,10 @@ class SMBus(object):
             cmdString+=pack('B', val)
 
         dataFlags = ""
-        for flag in range(I2C_FUNC_SMBUS_READ_BLOCK_DATA):
+        for flag in range(self.I2C_FUNC_SMBUS_READ_BLOCK_DATA):
             dataFlags+="B"
 
-        result = self._i2c.transaction(self._addr, cmdString, I2C_FUNC_SMBUS_READ_BLOCK_DATA)
+        result = self._i2c.transaction(self._addr, cmdString, self.I2C_FUNC_SMBUS_READ_BLOCK_DATA)
 
         return list(unpack(dataFlags, result[0]))
 


### PR DESCRIPTION
IoTPy :
>With large SFP frame, sometime the SFP frame was decoded even if it was not complete. 
This PR fix the reader loop and ensure that the SFP frame is complete before sending it to the decoder

weioSPI : 
>Fixed a problem with the block_read function
Added function to get and set the block size configuration

weioSmbus : 
>Added function to get and set the block size configuration