### PR TITLE
examples: bgColorLEDWEB : Fixed color position and value

### DIFF
--- a/examples/webApps/bgColorLEDWEB/main.py
+++ b/examples/webApps/bgColorLEDWEB/main.py
@@ -37,6 +37,9 @@ def buttonHandler(dataIn) :
        setColor(red,green,blue)
  
 def setColor(r,g,b):
+    # LED values are comprised between 0 and 100(%).
+    # For hardware reasons, LEDs lit when pin is LOW (0V)
+    # This is why the value is inverted here : 100% - led value
     pwmWrite(18,100-r)
     pwmWrite(19,100-g)
     pwmWrite(20,100-b)

--- a/examples/webApps/bgColorLEDWEB/main.py
+++ b/examples/webApps/bgColorLEDWEB/main.py
@@ -37,9 +37,9 @@ def buttonHandler(dataIn) :
        setColor(red,green,blue)
  
 def setColor(r,g,b):
-    pwmWrite(19,b)
-    pwmWrite(20,r)
-    pwmWrite(21,g)
+    pwmWrite(18,100-r)
+    pwmWrite(19,100-g)
+    pwmWrite(20,100-b)
  
     colorData = {}
     colorData["red"] = r


### PR DESCRIPTION
LED was not correctly set, and values must be inverted (LED ON = 0; LED OFF = 1)