### PR TITLE
Add all native language support in the kernel.

### DIFF
--- a/openWrt/weio-config-openwrt
+++ b/openWrt/weio-config-openwrt
@@ -2339,23 +2339,23 @@ CONFIG_PACKAGE_kmod-lib-crc16=y
 # Native Language Support
 #
 CONFIG_PACKAGE_kmod-nls-base=y
-# CONFIG_PACKAGE_kmod-nls-cp1250 is not set
-# CONFIG_PACKAGE_kmod-nls-cp1251 is not set
+CONFIG_PACKAGE_kmod-nls-cp1250=y
+CONFIG_PACKAGE_kmod-nls-cp1251=y
 CONFIG_PACKAGE_kmod-nls-cp437=y
-# CONFIG_PACKAGE_kmod-nls-cp775 is not set
+CONFIG_PACKAGE_kmod-nls-cp775=y
 CONFIG_PACKAGE_kmod-nls-cp850=y
 CONFIG_PACKAGE_kmod-nls-cp852=y
-# CONFIG_PACKAGE_kmod-nls-cp862 is not set
-# CONFIG_PACKAGE_kmod-nls-cp864 is not set
-# CONFIG_PACKAGE_kmod-nls-cp866 is not set
-# CONFIG_PACKAGE_kmod-nls-cp932 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-1 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-13 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-15 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-2 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-6 is not set
-# CONFIG_PACKAGE_kmod-nls-iso8859-8 is not set
-# CONFIG_PACKAGE_kmod-nls-koi8r is not set
+CONFIG_PACKAGE_kmod-nls-cp862=y
+CONFIG_PACKAGE_kmod-nls-cp864=y
+CONFIG_PACKAGE_kmod-nls-cp866=y
+CONFIG_PACKAGE_kmod-nls-cp932=y
+CONFIG_PACKAGE_kmod-nls-iso8859-1=y
+CONFIG_PACKAGE_kmod-nls-iso8859-13=y
+CONFIG_PACKAGE_kmod-nls-iso8859-15=y
+CONFIG_PACKAGE_kmod-nls-iso8859-2=y
+CONFIG_PACKAGE_kmod-nls-iso8859-6=y
+CONFIG_PACKAGE_kmod-nls-iso8859-8=y
+CONFIG_PACKAGE_kmod-nls-koi8r=y
 CONFIG_PACKAGE_kmod-nls-utf8=y
 
 #


### PR DESCRIPTION
These nls are important for removable device, and without them,
fat/vfat devices doesn't work correctly
(ref http://we-io.net/forum/viewtopic.php?f=2&t=775)

Tested by @jsiobj in #261 