### PR TITLE
Workaround to mount removable media if the partition number is missing.

### DIFF
--- a/openWrt/files/etc/hotplug.d/weio/10-weio-removable-devices
+++ b/openWrt/files/etc/hotplug.d/weio/10-weio-removable-devices
@@ -6,7 +6,7 @@
 for sd in `ls -d /sys/bus/scsi/drivers/sd/*/block/sd?`
 do
     block detect > /dev/null
-    sd_name=`basename $sd`1
+    [ -e $sd/`basename $sd`1 ] && sd_name=`basename $sd`1 || sd_name=`basename $sd`
     size=$(cat $sd/size)
     if [ "$size" != 0 -a "$size" != "" ]; then
         if !(mount |grep -q $sd_name); then


### PR DESCRIPTION
We don't know why the partition number is missing with some devices, but
tests shows that even without the partition number, the device could
be mounted with no problem.
This commit refer to issue #269 reported by @ondonadas