### PR TITLE
Added a delay between the bootloader hardware condition and device scan.

### DIFF
--- a/scripts/flash_lpc_fw.py
+++ b/scripts/flash_lpc_fw.py
@@ -103,6 +103,7 @@ class Upgrader:
 		self._gpio("0",self.uper_reset)
 		time.sleep(2) # wait for linux to settle after UPER reboot in to pgm state
 		self._gpio("0",self.uper_program)
+		time.sleep(2)
 
 		# find UPER block device
 		list_block_devs = glob.glob("/sys/block/sd*")


### PR DESCRIPTION
New batch uses LPC11U24, and for some unknown reasons, the time needed
for the USB enumeration is a bit bigger (few hundred millis), and then the
update script fails to detect the LPC bootloader.